### PR TITLE
Add campaign id to users

### DIFF
--- a/src/main/java/br/com/arnar/openforms/controller/FormController.java
+++ b/src/main/java/br/com/arnar/openforms/controller/FormController.java
@@ -21,6 +21,7 @@ import br.com.arnar.openforms.OpenformsApplication;
 import br.com.arnar.openforms.database.Form;
 import br.com.arnar.openforms.database.User;
 import br.com.arnar.openforms.exception.NoSuchEntryException;
+import br.com.arnar.openforms.exception.RequestValidationException;
 import br.com.arnar.openforms.request.form.FormSendRequest;
 import br.com.arnar.openforms.service.FormServiceInterface;
 import br.com.arnar.openforms.service.UserServiceInterface;
@@ -44,9 +45,12 @@ public class FormController extends ServiceController<FormServiceInterface> {
 
     @PostMapping(consumes = "application/json")
     @CrossOrigin(origins = "*")
-    public ResponseEntity<?> create(@RequestBody FormSendRequest req, @RequestParam Long ownerId) throws Exception {
+    public ResponseEntity<?> create(@RequestBody FormSendRequest req, @RequestParam String campaign) throws NoSuchEntryException, RequestValidationException {
         Form form = req.toEntity();
-        service.insert(form, ownerId);
+        User owner = userService.getByCampaignId(campaign);
+
+        service.insert(form, owner.getId());
+
         return created();
     }
 

--- a/src/main/java/br/com/arnar/openforms/database/User.java
+++ b/src/main/java/br/com/arnar/openforms/database/User.java
@@ -41,6 +41,9 @@ public class User implements Serializable {
     @Column(name = "company_name")
     private String companyName;
 
+    @Column(name = "campaign_id", unique = true)
+    private String campaignId;
+
     @Column(name = "email", unique = true)
     private String email;
 

--- a/src/main/java/br/com/arnar/openforms/repository/UserRepository.java
+++ b/src/main/java/br/com/arnar/openforms/repository/UserRepository.java
@@ -24,4 +24,6 @@ import java.util.Optional;
 
 public interface UserRepository extends CrudRepository<User, Long> {
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByCampaignId(String campaignId);
 }

--- a/src/main/java/br/com/arnar/openforms/service/UserServiceInterface.java
+++ b/src/main/java/br/com/arnar/openforms/service/UserServiceInterface.java
@@ -18,10 +18,8 @@
 package br.com.arnar.openforms.service;
 
 import br.com.arnar.openforms.database.User;
-import br.com.arnar.openforms.exception.IncorrectCredentialsException;
 import br.com.arnar.openforms.exception.NoSuchEntryException;
 import br.com.arnar.openforms.exception.ValueTakenException;
-import jakarta.servlet.http.HttpServletRequest;
 
 import java.security.spec.InvalidKeySpecException;
 
@@ -45,22 +43,7 @@ public interface UserServiceInterface {
      */
     User getByEmail(String email) throws NoSuchEntryException;
 
-    /**
-     * Updates the current user's email and password, after verifying the current credentials.
-     * Fails if the new email is already taken or if credentials do not match.
-     *
-     * @param request  the request containing the current user's JWT.
-     * @param newEmail the new email to set.
-     * @param oldEmail the user's current email (for verification).
-     * @param password the current password (for verification).
-     * @return the updated {@link User} entity.
-     * @throws ValueTakenException           if the new email is already registered.
-     * @throws InvalidKeySpecException       if password hashing fails.
-     * @throws NoSuchEntryException          if the current user cannot be found.
-     * @throws IncorrectCredentialsException if the old credentials are incorrect.
-     */
-    @SuppressWarnings("UnusedReturnValue")
-    User insertWithNewEmail(HttpServletRequest request, String newEmail, String oldEmail, String password) throws ValueTakenException, InvalidKeySpecException, NoSuchEntryException, IncorrectCredentialsException;
+    User getByCampaignId(String campaignId) throws NoSuchEntryException;
 
     /**
      * Deletes a user from the system.

--- a/src/main/java/br/com/arnar/openforms/service/implementation/UserService.java
+++ b/src/main/java/br/com/arnar/openforms/service/implementation/UserService.java
@@ -22,13 +22,11 @@ import br.com.arnar.openforms.exception.NoSuchEntryException;
 import br.com.arnar.openforms.exception.ValueTakenException;
 import br.com.arnar.openforms.repository.UserRepository;
 import br.com.arnar.openforms.service.UserServiceInterface;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import java.security.spec.InvalidKeySpecException;
 import java.util.Optional;
 
 @Service
@@ -66,17 +64,14 @@ public class UserService implements UserServiceInterface {
     }
 
     @Override
-    public User insertWithNewEmail(HttpServletRequest request, String newEmail, String oldEmail, String password) throws InvalidKeySpecException {
-        Optional<User> existingUserWithNewEmail = repository.findByEmail(newEmail);
+    public User getByCampaignId(String campaignId) throws NoSuchEntryException {
+        Optional<User> user = repository.findByCampaignId(campaignId);
 
-        if (existingUserWithNewEmail.isPresent()) {
-            throw new ValueTakenException("newEmail is already taken by another account.");
+        if (user.isEmpty()) {
+            throw new NoSuchEntryException("This campaign does not exist");
         }
 
-        User user = getByEmail(oldEmail);
-        user.setEmail(newEmail);
-
-        return insert(user);
+        return user.get();
     }
 
     @Override

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,8 +1,8 @@
-INSERT INTO member (username, company_name, email, password) VALUES
-    ('mock.admin', 'Arnar Dev', 'mock.admin@gmail.com', '276e2a19d5ff85a5d38d84a73aea5fcd58b7f7a245077b859b77fecd9db0b8c953a1e3328f472a73b4b7fbfb8781851bac27aab0f12550f5d90b0337b397d7f6aa6af3b0ee43fe8d54ce0c3cca518a4a');
+INSERT INTO member (username, company_name, campaign_id, email, password) VALUES
+    ('mock.admin', 'Arnar Dev', 'cb147f1', 'mock.admin@gmail.com', '276e2a19d5ff85a5d38d84a73aea5fcd58b7f7a245077b859b77fecd9db0b8c953a1e3328f472a73b4b7fbfb8781851bac27aab0f12550f5d90b0337b397d7f6aa6af3b0ee43fe8d54ce0c3cca518a4a');
 
-INSERT INTO member (username, company_name, email, password) VALUES
-    ('mock.other.user', 'Arnar Dev', 'mock.other.user@gmail.com', 'a');
+INSERT INTO member (username, company_name, campaign_id, email, password) VALUES
+    ('mock.other.user', 'Arnar Dev', '34c6fce', 'mock.other.user@gmail.com', 'a');
 
 INSERT INTO form (owner_id, name, phone_number, email, message) VALUES
     (1, 'Mock User Client', '5521921232132', 'mock.disposable@gmail.com', 'hello there');

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -6,6 +6,7 @@ CREATE TABLE member
     id           bigint GENERATED ALWAYS AS IDENTITY,
     username     varchar(128),
     company_name varchar(128),
+    campaign_id  char(7) UNIQUE,
     email        varchar(128) UNIQUE,
     password     varchar(240),
     PRIMARY KEY (id)

--- a/src/test/java/br/com/arnar/openforms/controller/FormControllerTest.java
+++ b/src/test/java/br/com/arnar/openforms/controller/FormControllerTest.java
@@ -37,11 +37,11 @@ public class FormControllerTest extends ControllerTest {
                 "hello world"
         );
 
-        req.post("/form?ownerId=1", form.toJson()).andExpect(status().isCreated());
+        req.post("/form?campaign=cb147f1", form.toJson()).andExpect(status().isCreated());
     }
 
     @Test
-    void inexistentOwnerId() throws Exception {
+    void inexistentCampaign() throws Exception {
         MockForm form = new MockForm(
                 "Arthur",
                 "21921342391",
@@ -49,7 +49,7 @@ public class FormControllerTest extends ControllerTest {
                 "hello world"
         );
 
-        req.post("/form?ownerId=3022", form.toJson()).andExpect(status().isNotFound());
+        req.post("/form?campaign=2led7f2", form.toJson()).andExpect(status().isNotFound());
     }
 
     @Test


### PR DESCRIPTION
Now each user has a campaign id that will be used to send the form without exposing the internal ID of the users